### PR TITLE
Fix test target import typo

### DIFF
--- a/ChatworkTaskReminderTests/ChatworkTaskRemiderTests.swift
+++ b/ChatworkTaskReminderTests/ChatworkTaskRemiderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import Testing
-@testable import ChatworkTaskRemider
+@testable import ChatworkTaskReminder
 
 struct ChatworkTaskRemiderTests {
 


### PR DESCRIPTION
## Summary
- corrected the `@testable import` line in `ChatworkTaskRemiderTests.swift`

## Testing
- `swiftc -parse ChatworkTaskReminderTests/ChatworkTaskRemiderTests.swift`
- ❌ `xcodebuild -version` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_6840f22c3544832b8be54ad34643b562